### PR TITLE
改进parse_task_ids中的任务ID提取逻辑

### DIFF
--- a/bilibili_drops_miner/utils.py
+++ b/bilibili_drops_miner/utils.py
@@ -21,12 +21,22 @@ def parse_room_ids(raw: str) -> list[int]:
 
 
 def parse_task_ids(raw: str) -> list[str]:
+    # 1. 尝试从粘贴的 URL/参数中提取 task_ids 的值
+    #    匹配 ? 或 & 之后的 task_ids=...（直到下一个 & 或结束）
+    match = re.search(r'(?:[?&])task_ids=([^&]+)', raw)
+    if match:
+        raw = match.group(1)  # 只保留逗号分隔的 ID 列表部分
+    # 2. 原有逻辑：统一分隔符并逐项清洗
     task_ids: list[str] = []
     for token in raw.replace("\n", ",").split(","):
         cleaned = token.strip()
         if not cleaned:
             continue
-        task_ids.append(cleaned)
+        # 3. 二次防护：如果 token 还包含 &，截断取前半部分
+        if '&' in cleaned:
+            cleaned = cleaned.split('&', 1)[0].strip()
+        if cleaned:
+            task_ids.append(cleaned)
     return task_ids
 
 


### PR DESCRIPTION
通过从URL中提取信息来改进任务 ID 的解析，并增加针对无效字符的二次防护。
原有代码复制包含task_ids的url请求时如果用户不慎带上末尾&web_location=888.146787的话，原逻辑仅通过逗号分隔后清洗会导致最后一个任务的丢失。
<img width="1503" height="1127" alt="ScreenShot_2026-05-22_112637_741" src="https://github.com/user-attachments/assets/39a622c9-039e-41db-ace8-43524e781223" />
<img width="1503" height="1127" alt="ScreenShot_2026-05-22_112705_063" src="https://github.com/user-attachments/assets/8967d948-3a52-4199-81bf-2cf6edff5cd6" />
<img width="2559" height="1368" alt="微信图片_20260522112844_39966_4" src="https://github.com/user-attachments/assets/98f27e9d-916d-4d5e-a6d5-6f1207654c3e" />
