### PR TITLE
fix: 在 macOS/Linux 上正确检测 Chrome/Edge 浏览器

### DIFF
--- a/bilibili_drops_miner/gui.py
+++ b/bilibili_drops_miner/gui.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import os
+import shutil
 import queue
 import re
 import sys
@@ -622,19 +623,54 @@ class MinerGUI(QMainWindow):
 
     @staticmethod
     def _find_browser(name: str) -> bool:
-        if name == "edge":
-            paths = [
-                r"C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe",
-                r"C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe",
-            ]
+        if sys.platform == "darwin":
+            if name == "edge":
+                paths = [
+                    "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+                ]
+            else:
+                paths = [
+                    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+                    "/Applications/Chromium.app/Contents/MacOS/Chromium",
+                ]
+        elif sys.platform == "win32":
+            if name == "edge":
+                paths = [
+                    r"C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe",
+                    r"C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe",
+                ]
+            else:
+                paths = [
+                    r"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+                    r"C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
+                    os.path.expandvars(
+                        r"%LOCALAPPDATA%\\Google\\Chrome\Application\\chrome.exe"
+                    ),
+                ]
         else:
-            paths = [
-                r"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
-                r"C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
-                os.path.expandvars(
-                    r"%LOCALAPPDATA%\\Google\\Chrome\Application\\chrome.exe"
-                ),
-            ]
+            if name == "edge":
+                candidates = (
+                    "microsoft-edge",
+                    "microsoft-edge-stable",
+                    "/usr/bin/microsoft-edge",
+                    "/usr/bin/microsoft-edge-stable",
+                )
+            else:
+                candidates = (
+                    "google-chrome",
+                    "google-chrome-stable",
+                    "chromium",
+                    "chromium-browser",
+                    "/usr/bin/google-chrome",
+                    "/usr/bin/chromium",
+                )
+            for candidate in candidates:
+                if candidate.startswith("/"):
+                    if os.path.exists(candidate):
+                        return True
+                elif shutil.which(candidate):
+                    return True
+            return False
         return any(os.path.exists(p) for p in paths)
 
     @staticmethod


### PR DESCRIPTION
## Summary
- 修复 `_find_browser` 仅在 Windows 路径下查找 Chrome/Edge 的问题
- 补充 macOS（`.app` 安装路径）与 Linux（`which` / 常见路径）的浏览器检测
- 解决 macOS 上 GUI「自动获取」误报「未找到可用浏览器（Edge/Chrome），最后错误: None」

## Test plan
- [x] macOS：已安装 Google Chrome 时，`_find_browser('chrome')` 返回 True
- [ ] macOS：重启 GUI 后「自动获取 Cookie/任务 ID」可弹出 Chrome
- [ ] Windows：自动获取功能仍正常