### PR TITLE
feat: 新增一键领取全部掉宝奖励功能

### DIFF
--- a/bilibili_drops_miner/client.py
+++ b/bilibili_drops_miner/client.py
@@ -69,6 +69,37 @@ class TaskProgress:
             return False
 
 
+@dataclass(slots=True)
+class MissionRewardInfo:
+    task_id: str
+    task_name: str
+    status: int
+    message: str
+    act_id: str
+    act_name: str
+    reward_name: str
+
+    @property
+    def is_claimable(self) -> bool:
+        return self.status == 0
+
+    @property
+    def is_claimed(self) -> bool:
+        return self.status == 6
+
+
+@dataclass(slots=True)
+class MissionRewardClaimResult:
+    task_id: str
+    task_name: str
+    reward_name: str
+    status: int
+    message: str
+    success: bool
+    skipped: bool
+    code: int | str | None = None
+
+
 class BilibiliClient:
     MIXIN_KEY_ENC_TAB = [
         46,
@@ -261,6 +292,23 @@ class BilibiliClient:
             "Cookie": self.cookie_header,
         }
 
+    def _mission_headers(self, task_id: str) -> dict[str, str]:
+        return {
+            "Referer": (
+                "https://www.bilibili.com/blackboard/era/award-exchange.html"
+                f"?task_id={urllib.parse.quote(task_id, safe='')}"
+            ),
+            "Origin": "https://www.bilibili.com",
+            "User-Agent": self.user_agent,
+            "Cookie": self.cookie_header,
+        }
+
+    @staticmethod
+    def _is_rate_limited_payload(payload: dict[str, Any]) -> bool:
+        code = str(payload.get("code") or "")
+        message = str(payload.get("message") or "")
+        return code in {"-702", "-509"} or "频率" in message or "频繁" in message
+
     async def _request_with_transient_retry(
         self,
         request_coro,
@@ -376,6 +424,37 @@ class BilibiliClient:
                     params=signed_params,
                     headers=headers,
                     follow_redirects=follow_redirects,
+                ),
+                method="POST",
+                url=url,
+            )
+            response.raise_for_status()
+            payload = response.json()
+            if payload.get("code") == 0:
+                return payload
+            if retry == 0 and retry_on_wbi_miss:
+                self._wbi_cache = None
+        return payload
+
+    async def _signed_post_form_json(
+        self,
+        url: str,
+        params: dict[str, Any],
+        body: dict[str, Any],
+        *,
+        headers: dict[str, str] | None = None,
+        retry_on_wbi_miss: bool = True,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {}
+        retries = 2 if retry_on_wbi_miss else 1
+        for retry in range(retries):
+            signed_params = await self.sign_wbi(params)
+            response = await self._request_with_transient_retry(
+                lambda: self._http.post(
+                    url,
+                    params=signed_params,
+                    data=body,
+                    headers=headers,
                 ),
                 method="POST",
                 url=url,
@@ -719,3 +798,150 @@ class BilibiliClient:
                 )
             )
         return progresses
+
+    async def get_mission_reward_info(self, task_id: str) -> MissionRewardInfo:
+        normalized_id = task_id.strip()
+        if not normalized_id:
+            raise ValueError("task_id 不能为空")
+
+        payload: dict[str, Any] = {}
+        for attempt, delay in enumerate((0.0, 1.5, 3.0), start=1):
+            if delay > 0:
+                await asyncio.sleep(delay)
+            payload = await self._signed_get_json(
+                "https://api.bilibili.com/x/activity_components/mission/info",
+                {"task_id": normalized_id},
+                headers=self._mission_headers(normalized_id),
+                retry_on_wbi_miss=True,
+            )
+            if payload.get("code") == 0 or not self._is_rate_limited_payload(payload):
+                break
+            LOGGER.info(
+                "查询领奖信息触发限频 task_id=%s attempt=%s，稍后重试",
+                normalized_id,
+                attempt,
+            )
+        if payload.get("code") != 0:
+            raise ValueError(f"查询领奖信息失败: {payload.get('message')}")
+
+        data = payload.get("data") or {}
+        reward_info = data.get("reward_info") or {}
+        return MissionRewardInfo(
+            task_id=str(data.get("task_id") or normalized_id),
+            task_name=str(data.get("task_name") or normalized_id),
+            status=int(data.get("status") or 0),
+            message=str(data.get("message") or ""),
+            act_id=str(data.get("act_id") or ""),
+            act_name=str(data.get("act_name") or ""),
+            reward_name=str(reward_info.get("award_name") or ""),
+        )
+
+    async def receive_mission_reward(
+        self, info: MissionRewardInfo
+    ) -> MissionRewardClaimResult:
+        if info.is_claimed:
+            return MissionRewardClaimResult(
+                task_id=info.task_id,
+                task_name=info.task_name,
+                reward_name=info.reward_name,
+                status=info.status,
+                message=info.message or "已领取",
+                success=True,
+                skipped=True,
+            )
+        if not info.is_claimable:
+            return MissionRewardClaimResult(
+                task_id=info.task_id,
+                task_name=info.task_name,
+                reward_name=info.reward_name,
+                status=info.status,
+                message=info.message or "当前状态不可领取",
+                success=False,
+                skipped=True,
+            )
+
+        if not self.bili_jct:
+            raise ValueError("cookie 缺少 bili_jct，无法领取奖励")
+
+        body = {
+            "task_id": info.task_id,
+            "activity_id": info.act_id,
+            "activity_name": info.act_name,
+            "task_name": info.task_name,
+            "reward_name": info.reward_name,
+            "gaia_vtoken": "",
+            "receive_from": "missionPage",
+            "csrf": self.bili_jct,
+            "csrf_token": self.bili_jct,
+        }
+        payload: dict[str, Any] = {}
+        for attempt, delay in enumerate((0.0, 1.5, 3.0), start=1):
+            if delay > 0:
+                await asyncio.sleep(delay)
+            payload = await self._signed_post_form_json(
+                "https://api.bilibili.com/x/activity_components/mission/receive",
+                {},
+                body,
+                headers={
+                    **self._mission_headers(info.task_id),
+                    "Content-Type": "application/x-www-form-urlencoded",
+                },
+                retry_on_wbi_miss=True,
+            )
+            if payload.get("code") == 0 or not self._is_rate_limited_payload(payload):
+                break
+            LOGGER.info(
+                "领取奖励触发限频 task_id=%s attempt=%s，稍后重试",
+                info.task_id,
+                attempt,
+            )
+        code = payload.get("code")
+        message = str(payload.get("message") or "")
+        if code == 0:
+            if not message or message == "0":
+                message = "领取成功"
+            return MissionRewardClaimResult(
+                task_id=info.task_id,
+                task_name=info.task_name,
+                reward_name=info.reward_name,
+                status=6,
+                message=message,
+                success=True,
+                skipped=False,
+                code=code,
+            )
+        return MissionRewardClaimResult(
+            task_id=info.task_id,
+            task_name=info.task_name,
+            reward_name=info.reward_name,
+            status=info.status,
+            message=message or "领取失败",
+            success=False,
+            skipped=False,
+            code=code,
+        )
+
+    async def receive_all_mission_rewards(
+        self, task_ids: list[str]
+    ) -> list[MissionRewardClaimResult]:
+        normalized_ids = [task_id.strip() for task_id in task_ids if task_id.strip()]
+        results: list[MissionRewardClaimResult] = []
+        for index, task_id in enumerate(normalized_ids):
+            try:
+                info = await self.get_mission_reward_info(task_id)
+                results.append(await self.receive_mission_reward(info))
+            except Exception as exc:
+                results.append(
+                    MissionRewardClaimResult(
+                        task_id=task_id,
+                        task_name=task_id,
+                        reward_name="",
+                        status=-1,
+                        message=str(exc),
+                        success=False,
+                        skipped=False,
+                    )
+                )
+            if index < len(normalized_ids) - 1:
+                await asyncio.sleep(1.2)
+        return results

--- a/bilibili_drops_miner/gui.py
+++ b/bilibili_drops_miner/gui.py
@@ -121,6 +121,8 @@ class MinerGUI(QMainWindow):
         self._task_refresh_inflight: bool = False
         self._task_refresh_queued: bool = False
         self._task_refresh_trigger_pending: bool = False
+        self._reward_claim_lock = threading.Lock()
+        self._reward_claim_inflight: bool = False
         self._stopping_in_progress: bool = False
         self._stop_poll_started_at: float | None = None
         self._stop_timeout_warned: bool = False
@@ -267,6 +269,8 @@ class MinerGUI(QMainWindow):
         task_title.setStyleSheet("color:#f5f6f8;")
         task_header.addWidget(task_title)
         task_header.addStretch(1)
+        self.claim_rewards_btn = self._make_button("领取奖励", "blue", self.claim_rewards)
+        task_header.addWidget(self.claim_rewards_btn)
         task_header.addWidget(self._make_button("手动刷新", "", self.refresh_tasks))
         task_layout.addLayout(task_header)
 
@@ -620,6 +624,48 @@ class MinerGUI(QMainWindow):
                 self._post_ui_task(self._complete_task_refresh, result_text, rerun)
 
         threading.Thread(target=_do, daemon=True, name="gui-task-refresh").start()
+
+    def claim_rewards(self, *args, **kwargs) -> None:
+        # QPushButton.clicked may pass a bool (checked) — ignore positional args.
+        cookie = self.cookie_edit.text().strip()
+        if not cookie:
+            self._show_warning("提示", "请先填写 Cookie")
+            return
+        task_ids = parse_task_ids(self.task_ids_edit.text().strip())
+        if not task_ids:
+            self._show_warning("提示", "请先填写或自动获取任务 ID")
+            return
+
+        with self._reward_claim_lock:
+            if self._reward_claim_inflight:
+                self._set_task_progress_text("已有领奖任务进行中，请稍候...")
+                return
+            self._reward_claim_inflight = True
+
+        self._set_task_progress_text("正在领取全部可领取奖励...")
+
+        def _do() -> None:
+            result_text = ""
+            try:
+
+                async def _claim():
+                    client = BilibiliClient(cookie)
+                    try:
+                        return await client.receive_all_mission_rewards(task_ids)
+                    finally:
+                        await client.close()
+
+                results = asyncio.run(_claim())
+                result_text = self._format_reward_claim_results(results)
+            except Exception as exc:
+                logging.getLogger(__name__).warning("领取奖励失败: %s", exc)
+                result_text = f"领取奖励失败: {exc}"
+            finally:
+                with self._reward_claim_lock:
+                    self._reward_claim_inflight = False
+                self._post_ui_task(self._set_task_progress_text, result_text)
+
+        threading.Thread(target=_do, daemon=True, name="gui-reward-claim").start()
 
     @staticmethod
     def _find_browser(name: str) -> bool:
@@ -1313,6 +1359,55 @@ class MinerGUI(QMainWindow):
                 lines.append(f"{task.task_name} ({cur}/{target})")
                 lines.append(f"  {bar}{status}")
         return "\n".join(lines)
+
+    @staticmethod
+    def _format_reward_claim_results(results: list) -> str:
+        if not results:
+            return "无可领取任务数据"
+
+        success_count = sum(1 for item in results if item.success and not item.skipped)
+        claimed_count = sum(1 for item in results if item.success and item.skipped)
+        skipped_count = sum(1 for item in results if item.skipped and not item.success)
+        failed_count = sum(1 for item in results if not item.success and not item.skipped)
+
+        lines = [
+            "领取结果",
+            (
+                f"领取成功 {success_count} 个，已领取 {claimed_count} 个，"
+                f"跳过 {skipped_count} 个，失败 {failed_count} 个"
+            ),
+            "",
+        ]
+        for item in results:
+            if item.success and item.skipped:
+                prefix = "已领取"
+            elif item.success:
+                prefix = "领取成功"
+            elif item.skipped:
+                prefix = "跳过"
+            else:
+                prefix = "失败"
+
+            name = item.task_name or item.task_id
+            reward = f" - {item.reward_name}" if item.reward_name else ""
+            if item.success:
+                lines.append(f"[{prefix}] {name}{reward}")
+                continue
+
+            message = MinerGUI._clean_reward_message(item.message, item.skipped)
+            if item.code is not None and item.code != 0:
+                message = f"{message} (code={item.code})"
+            lines.append(f"[{prefix}] {name}{reward}: {message}")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _clean_reward_message(message: str, skipped: bool) -> str:
+        cleaned = str(message or "").strip()
+        if cleaned in {"", "0", "查看奖励"}:
+            if skipped:
+                return "当前不可领取"
+            return "领取失败"
+        return cleaned
 
     def _sync_config_to_miner(self) -> None:
         if self.miner is None:

--- a/bilibili_drops_miner/utils.py
+++ b/bilibili_drops_miner/utils.py
@@ -22,8 +22,8 @@ def parse_room_ids(raw: str) -> list[int]:
 
 def parse_task_ids(raw: str) -> list[str]:
     # 1. 尝试从粘贴的 URL/参数中提取 task_ids 的值
-    #    匹配 ? 或 & 之后的 task_ids=...（直到下一个 & 或结束）
-    match = re.search(r'(?:[?&])task_ids=([^&]+)', raw)
+    #    匹配开头、? 或 & 之后的 task_ids=...（直到下一个 & 或结束）
+    match = re.search(r"(?:^|[?&])task_ids=([^&]+)", raw)
     if match:
         raw = match.group(1)  # 只保留逗号分隔的 ID 列表部分
     # 2. 原有逻辑：统一分隔符并逐项清洗


### PR DESCRIPTION
## 功能说明

新增“一键领取全部掉宝奖励”功能，用于避免在完成掉宝任务后需要逐个手动领取奖励。

## 主要改动

- 新增批量领取全部可领取掉宝奖励的逻辑
- 在 GUI 中增加一键领取入口
- 补充相关工具函数，用于处理领取状态和请求逻辑

## 测试情况

已在 Windows 环境下通过本地 GUI 运行测试，确认可正常识别并领取可领取的掉宝奖励。