### PR TITLE
修复按日期分组掉宝任务识别

### DIFF
--- a/bilibili_drops_miner/gui.py
+++ b/bilibili_drops_miner/gui.py
@@ -20,6 +20,7 @@ from PySide6.QtWidgets import (
     QFileDialog,
     QFrame,
     QHBoxLayout,
+    QInputDialog,
     QLabel,
     QLineEdit,
     QMainWindow,
@@ -35,7 +36,11 @@ from bilibili_drops_miner.client import BilibiliClient
 from bilibili_drops_miner.config import MinerConfig
 from bilibili_drops_miner.logging_utils import setup_logging
 from bilibili_drops_miner.miner import BilibiliWatchTimeMiner
-from bilibili_drops_miner.utils import parse_room_ids, parse_task_ids
+from bilibili_drops_miner.utils import (
+    extract_bili_live_task_groups,
+    parse_room_ids,
+    parse_task_ids,
+)
 
 
 class QueueLogHandler(logging.Handler):
@@ -749,6 +754,62 @@ class MinerGUI(QMainWindow):
     def _apply_auto_task_ids(self, task_ids_str: str) -> None:
         self.task_ids_edit.setText(task_ids_str)
 
+    def _apply_selected_task_group(
+        self,
+        room_id: int | None,
+        task_groups: list[dict[str, object]],
+    ) -> None:
+        if room_id is not None and room_id > 0:
+            self._apply_auto_room_id(room_id)
+
+        if not task_groups:
+            self._show_warning("提示", "未从当前直播页解析到掉宝任务分组")
+            return
+
+        options = [
+            f"{str(group.get('label') or '任务组')} ({len(group.get('task_ids') or [])} 个任务)"
+            for group in task_groups
+        ]
+        default_index = 0
+        for index, group in enumerate(task_groups):
+            if bool(group.get("active")):
+                default_index = index
+                break
+
+        selected_option, ok = QInputDialog.getItem(
+            self,
+            "选择掉宝任务组",
+            "检测到多个按日期分组的掉宝任务，请选择要填入的一组：",
+            options,
+            default_index,
+            False,
+        )
+        if not ok:
+            logging.getLogger(__name__).info("用户取消了掉宝任务组选择")
+            return
+
+        try:
+            selected_index = options.index(selected_option)
+        except ValueError:
+            selected_index = default_index
+
+        selected_group = task_groups[selected_index]
+        task_ids = [
+            str(task_id).strip()
+            for task_id in (selected_group.get("task_ids") or [])
+            if str(task_id).strip()
+        ]
+        if not task_ids:
+            self._show_warning("提示", "所选分组中没有可用的任务 ID")
+            return
+
+        self._apply_auto_task_ids(",".join(task_ids))
+        logging.getLogger(__name__).info(
+            "任务ID获取成功: %s -> %s",
+            selected_group.get("label") or f"任务组 {selected_index + 1}",
+            ",".join(task_ids),
+        )
+
     def _browser_sniff(
         self,
         url_keyword: str | None,
@@ -756,6 +817,7 @@ class MinerGUI(QMainWindow):
         on_network_match=None,
         on_cookies=None,
         on_page_url=None,
+        on_page_html=None,
     ) -> None:
         def _do() -> None:
             server = None
@@ -775,6 +837,7 @@ class MinerGUI(QMainWindow):
                 need_net = bool(url_keyword and on_network_match)
                 need_cookie = on_cookies is not None
                 need_url = on_page_url is not None
+                need_html = on_page_html is not None
 
                 net_captured: list = []
                 cookie_captured: list = []
@@ -1093,6 +1156,7 @@ class MinerGUI(QMainWindow):
                 cookie_done = False
                 net_done = False
                 url_done = False
+                html_done = False
                 last_cookie_count = 0
                 for i in range(120):
                     if need_cookie and not cookie_done and cookie_captured:
@@ -1142,10 +1206,24 @@ class MinerGUI(QMainWindow):
                                 logging.getLogger(__name__).exception("on_page_url 回调失败")
                             url_done = True
 
+                    if need_html and not html_done:
+                        try:
+                            cur_url = driver.current_url or ""
+                        except Exception:
+                            cur_url = ""
+                        room_id = MinerGUI._extract_room_id_from_live_url(cur_url)
+                        if room_id is not None:
+                            try:
+                                page_html = driver.page_source or ""
+                                html_done = bool(on_page_html(page_html, cur_url))
+                            except Exception:
+                                logging.getLogger(__name__).exception("页面源码回调失败")
+
                     if (
                         (not need_cookie or cookie_done)
                         and (not need_net or net_done)
                         and (not need_url or url_done)
+                        and (not need_html or html_done)
                     ):
                         break
 
@@ -1228,34 +1306,20 @@ class MinerGUI(QMainWindow):
         if ok != QMessageBox.Ok:
             return
 
-        def on_match(payload):
-            payload_data = payload if isinstance(payload, dict) else {}
-            request_url = str(payload_data.get("url") or "")
-            page_url = str(payload_data.get("page_url") or "")
+        def on_page_html(page_html: str, page_url: str) -> bool:
             room_id = self._extract_room_id_from_live_url(page_url)
-            if room_id is None:
-                room_id = self._extract_room_id_from_live_url(request_url)
-            if room_id is not None:
-                self._post_ui_task(self._apply_auto_room_id, room_id)
-                logging.getLogger(__name__).info("房间号获取成功: %s", room_id)
-
-            data = payload_data.get("data")
-            if not isinstance(data, dict):
-                raise ValueError("task response payload invalid")
-            if data.get("code") != 0:
-                raise ValueError("response code != 0")
-            tasks = data.get("data", {}).get("list", [])
-            task_ids = [t.get("task_id") for t in tasks if t.get("task_id")]
-            if not task_ids:
-                raise ValueError("empty task list")
-            self._post_ui_task(self._apply_auto_task_ids, ",".join(task_ids))
-            logging.getLogger(__name__).info("任务ID获取成功: %s", ",".join(task_ids))
+            task_groups = extract_bili_live_task_groups(page_html)
+            if not task_groups:
+                return False
+            self._post_ui_task(self._apply_selected_task_group, room_id, task_groups)
+            return True
 
         self._browser_sniff(
-            "/x/task/totalv2",
-            "已打开浏览器，请打开有当前任务的直播间或点击刷新任务",
-            on_network_match=on_match,
+            None,
+            "已打开浏览器，请打开有当前任务的直播间并等待页面加载完成",
+            on_page_html=on_page_html,
         )
+        return
 
     def auto_fetch_cookie(self) -> None:
         ok = QMessageBox.question(

--- a/bilibili_drops_miner/utils.py
+++ b/bilibili_drops_miner/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 
 COOKIE_PATTERN = re.compile(r"\s*([^=;\s]+)\s*=\s*([^;]*)")
@@ -38,6 +39,196 @@ def parse_task_ids(raw: str) -> list[str]:
         if cleaned:
             task_ids.append(cleaned)
     return task_ids
+
+
+def _extract_json_object_after_marker(raw: str, marker: str) -> dict:
+    marker_index = raw.find(marker)
+    if marker_index < 0:
+        raise ValueError(f"未找到标记: {marker}")
+
+    object_start = raw.find("{", marker_index + len(marker))
+    if object_start < 0:
+        raise ValueError(f"标记后未找到 JSON 对象: {marker}")
+
+    depth = 0
+    in_string = False
+    escape = False
+    object_end = -1
+
+    for index in range(object_start, len(raw)):
+        char = raw[index]
+        if in_string:
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == '"':
+                in_string = False
+            continue
+
+        if char == '"':
+            in_string = True
+            continue
+        if char == "{":
+            depth += 1
+            continue
+        if char == "}":
+            depth -= 1
+            if depth == 0:
+                object_end = index + 1
+                break
+
+    if object_end <= object_start:
+        raise ValueError(f"标记后的 JSON 对象不完整: {marker}")
+
+    return json.loads(raw[object_start:object_end])
+
+
+def _task_group_position(position_boxes: list, index: int) -> tuple[float, float] | None:
+    if index >= len(position_boxes):
+        return None
+    position_box = position_boxes[index]
+    if not isinstance(position_box, dict):
+        return None
+    left = position_box.get("left")
+    top = position_box.get("top")
+    if not isinstance(left, (int, float)) or not isinstance(top, (int, float)):
+        return None
+    return float(left), float(top)
+
+
+def _is_same_panel_column(
+    prev_position: tuple[float, float] | None,
+    cur_position: tuple[float, float] | None,
+) -> bool:
+    if prev_position is None or cur_position is None:
+        return False
+
+    prev_left, prev_top = prev_position
+    cur_left, cur_top = cur_position
+    return abs(prev_top - cur_top) <= 10 and abs(prev_left - cur_left) >= 200
+
+
+def _partition_task_group_indexes(
+    task_groups: list,
+    panels: list,
+    position_boxes: list,
+) -> list[list[int]]:
+    if not panels:
+        return []
+    if len(task_groups) <= len(panels):
+        return [[index] for index in range(len(task_groups))]
+
+    blocks: list[list[int]] = []
+    for index in range(len(task_groups)):
+        prev_position = _task_group_position(position_boxes, index - 1)
+        cur_position = _task_group_position(position_boxes, index)
+        if blocks and _is_same_panel_column(prev_position, cur_position):
+            blocks[-1].append(index)
+            continue
+        blocks.append([index])
+
+    if len(blocks) == len(panels):
+        return blocks
+
+    # 页面状态缺少明确的父子关系时，保底按顺序分配：
+    # 前面的标签页各取一组，最后一个标签页合并剩余任务列表，避免漏掉多列任务。
+    partitioned = [[index] for index in range(min(len(panels) - 1, len(task_groups)))]
+    remaining_start = len(partitioned)
+    if remaining_start < len(task_groups):
+        partitioned.append(list(range(remaining_start, len(task_groups))))
+    return partitioned
+
+
+def _extract_task_ids_from_task_group(task_group: dict, seen: set[str]) -> list[str]:
+    task_ids: list[str] = []
+    for task in task_group.get("tasklist") or []:
+        if not isinstance(task, dict):
+            continue
+        task_id = str(task.get("taskId") or "").strip()
+        if not task_id or task_id in seen:
+            continue
+        seen.add(task_id)
+        task_ids.append(task_id)
+    return task_ids
+
+
+def extract_bili_live_task_groups(page_html: str) -> list[dict[str, object]]:
+    try:
+        state = _extract_json_object_after_marker(page_html, "window.__initialState =")
+    except (ValueError, json.JSONDecodeError):
+        return []
+
+    task_groups = state.get("EraTasklistPc") or []
+    position_boxes = state.get("EvaPositionBox") or []
+    panels = state.get("EvaTabs.Panel") or []
+    tabs = state.get("EvaTabs") or []
+    if not isinstance(task_groups, list) or not isinstance(panels, list):
+        return []
+    if not isinstance(position_boxes, list):
+        position_boxes = []
+
+    active_panel_id = ""
+    if tabs and isinstance(tabs[0], dict):
+        active_panel_id = str(tabs[0].get("activatedTabPanelId") or "")
+
+    groups: list[dict[str, object]] = []
+    task_group_indexes_by_panel = _partition_task_group_indexes(
+        task_groups,
+        panels,
+        position_boxes,
+    )
+    for index, panel in enumerate(panels):
+        if not isinstance(panel, dict) or index >= len(task_group_indexes_by_panel):
+            continue
+
+        tab_item = panel.get("tabItem") or {}
+        if not isinstance(tab_item, dict):
+            tab_item = {}
+        tab_item_props = tab_item.get("tabItemProps") or {}
+        activated_props = tab_item.get("activatedTabItemProps") or {}
+        if not isinstance(tab_item_props, dict):
+            tab_item_props = {}
+        if not isinstance(activated_props, dict):
+            activated_props = {}
+        tab_text = tab_item_props.get("textContent") or {}
+        activated_text = activated_props.get("textContent") or {}
+        if not isinstance(tab_text, dict):
+            tab_text = {}
+        if not isinstance(activated_text, dict):
+            activated_text = {}
+        label = (
+            str(
+                tab_text.get("content")
+                or activated_text.get("content")
+                or f"任务组 {index + 1}"
+            ).strip()
+            or f"任务组 {index + 1}"
+        )
+        panel_id = str(panel.get("id") or "")
+
+        task_ids: list[str] = []
+        seen: set[str] = set()
+        for task_group_index in task_group_indexes_by_panel[index]:
+            if task_group_index >= len(task_groups):
+                continue
+            task_group = task_groups[task_group_index]
+            if not isinstance(task_group, dict):
+                continue
+            task_ids.extend(_extract_task_ids_from_task_group(task_group, seen))
+
+        if not task_ids:
+            continue
+
+        groups.append(
+            {
+                "label": label,
+                "task_ids": task_ids,
+                "active": panel_id == active_panel_id,
+            }
+        )
+
+    return groups
 
 
 def parse_cookie(cookie_text: str) -> dict[str, str]:


### PR DESCRIPTION
## 变更内容

- 自动获取任务 ID 时，从直播页内嵌状态中解析全部掉宝任务分组。
- 按标签页文字（例如 5月22日、5月23日、5月24日）弹窗让用户选择要填入的任务组。
- 不再只消费默认标签页的第一组任务响应，避免漏掉后续日期任务。

## 问题原因

直播间掉宝页面会把多个日期的任务放在同一份页面状态里，但默认只展开当前标签页。原逻辑只监听首个任务接口响应，所以只能识别默认日期，无法拿到其它标签页对应的任务 ID。

## 验证

- 通过：`py -3 -m py_compile bilibili_gui.py bilibili_drops_miner\gui.py bilibili_drops_miner\utils.py`
- 使用 `https://live.bilibili.com/23612045` 验证可解析 5月22日、5月23日、5月24日 三组任务。
- 本地 GUI 测试通过，可弹窗选择任务分组并填入对应任务 ID。

Closes #20