### PR TITLE
feat: 持久化 GUI 状态

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,9 @@ on:
       - 'requirements.txt'
       - 'build.py'
       - 'build_nuitka.py'
-      - 'bilibili.py'
       - 'bilibili_gui.py'
       - 'bilibili_drops_miner/**'
+      - '!bilibili_drops_miner/cli.py'
       - 'img/app.ico'
       - 'img/app.icns'
   workflow_dispatch:
@@ -56,19 +56,9 @@ jobs:
           echo "update_channel=$update_channel" >> "$GITHUB_OUTPUT"
 
   build-windows:
-    name: Windows ${{ matrix.target }} (Nuitka)
+    name: Windows GUI (Nuitka)
     needs: prepare
     runs-on: windows-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: gui
-            package: bilibili-drops-miner-win
-            folder: Bilibili Drops Miner
-          - target: cli
-            package: bilibili-drops-miner-cli-win
-            folder: bilibili-drops-miner-cli
     steps:
       - uses: actions/checkout@v4
 
@@ -96,9 +86,9 @@ jobs:
             ~\AppData\Local\Nuitka
             ~\AppData\Local\ccache
             dist-nuitka\*.build
-          key: ${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-nuitka-${{ matrix.target }}-${{ needs.prepare.outputs.version }}-${{ hashFiles('requirements.txt', 'build_nuitka.py', 'bilibili.py', 'bilibili_gui.py', 'bilibili_drops_miner/**/*.py') }}
+          key: ${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-nuitka-gui-${{ needs.prepare.outputs.version }}-${{ hashFiles('requirements.txt', 'build_nuitka.py', 'bilibili_gui.py', 'bilibili_drops_miner/**/*.py') }}
           restore-keys: |
-            ${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-nuitka-${{ matrix.target }}-
+            ${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-nuitka-gui-
             ${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-nuitka-
 
       - name: Install dependencies
@@ -107,23 +97,23 @@ jobs:
           python -m pip install --disable-pip-version-check nuitka ordered-set zstandard
 
       - name: Build with Nuitka
-        run: python build_nuitka.py --target ${{ matrix.target }}
+        run: python build_nuitka.py --target gui
 
       - name: Package ZIP
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force dist | Out-Null
-          Compress-Archive -Path "dist-nuitka/${{ matrix.folder }}" -DestinationPath "dist/${{ matrix.package }}-${{ needs.prepare.outputs.version }}.zip" -CompressionLevel Fastest -Force
+          Compress-Archive -Path "dist-nuitka/Bilibili Drops Miner" -DestinationPath "dist/bilibili-drops-miner-win-${{ needs.prepare.outputs.version }}.zip" -CompressionLevel Fastest -Force
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.package }}
-          path: dist/${{ matrix.package }}-*.zip
+          name: bilibili-drops-miner-win
+          path: dist/bilibili-drops-miner-win-*.zip
           retention-days: 30
 
   build-macos:
-    name: macOS gui (PyInstaller)
+    name: macOS GUI (PyInstaller)
     needs: prepare
     runs-on: macos-latest
     steps:

--- a/bilibili_drops_miner/gui_parts/gui_state.py
+++ b/bilibili_drops_miner/gui_parts/gui_state.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from PySide6.QtCore import QByteArray, QSettings
+
+
+SETTINGS_ORGANIZATION = "BiliBiliDropsMiner"
+SETTINGS_APPLICATION = "BilibiliDropsMiner"
+
+WINDOW_GEOMETRY_KEY = "main_window/geometry"
+LAST_CONFIG_PATH_KEY = "config/last_path"
+
+
+class GuiStateStore:
+    """Persist local GUI state without copying configuration contents."""
+
+    def __init__(self, settings: QSettings | None = None) -> None:
+        self._settings = (
+            settings
+            if settings is not None
+            else QSettings(SETTINGS_ORGANIZATION, SETTINGS_APPLICATION)
+        )
+
+    def window_geometry(self) -> QByteArray:
+        value = self._settings.value(WINDOW_GEOMETRY_KEY, QByteArray())
+        if isinstance(value, QByteArray):
+            return QByteArray(value)
+        if isinstance(value, (bytes, bytearray)):
+            return QByteArray(value)
+        return QByteArray()
+
+    def set_window_geometry(self, geometry: QByteArray) -> None:
+        self._settings.setValue(WINDOW_GEOMETRY_KEY, geometry)
+
+    def last_config_path(self) -> Path | None:
+        value = self._settings.value(LAST_CONFIG_PATH_KEY, "")
+        path_text = str(value or "").strip()
+        if not path_text:
+            return None
+        return Path(path_text)
+
+    def set_last_config_path(self, path: str | Path) -> None:
+        normalized = Path(path).expanduser().resolve(strict=False)
+        self._settings.setValue(LAST_CONFIG_PATH_KEY, str(normalized))
+
+    def clear_last_config_path(self) -> None:
+        self._settings.remove(LAST_CONFIG_PATH_KEY)
+
+    def sync(self) -> None:
+        self._settings.sync()

--- a/bilibili_drops_miner/gui_parts/main_window.py
+++ b/bilibili_drops_miner/gui_parts/main_window.py
@@ -5,6 +5,7 @@ import queue
 import sys
 import threading
 import webbrowser
+from pathlib import Path
 
 from PySide6.QtCore import Qt, QTimer, Signal
 from PySide6.QtGui import QCloseEvent
@@ -19,11 +20,13 @@ from bilibili_drops_miner.config import MinerConfig
 from bilibili_drops_miner.gui_parts.app_style import configure_qt_app
 from bilibili_drops_miner.gui_parts.browser_actions import BrowserActions
 from bilibili_drops_miner.gui_parts.config_io import (
+    GuiConfigValues,
     build_config_payload,
     load_config_data,
     save_config_data,
     values_from_config_data,
 )
+from bilibili_drops_miner.gui_parts.gui_state import GuiStateStore
 from bilibili_drops_miner.gui_parts.log_handler import QueueLogHandler
 from bilibili_drops_miner.gui_parts.main_layout import (
     MainWindowCallbacks,
@@ -65,8 +68,9 @@ class MinerGUI(QMainWindow):
     # Qt auto-queues the call onto the GUI thread (sender lives in non-Qt thread).
     ui_call = Signal(object, tuple, dict)
 
-    def __init__(self) -> None:
+    def __init__(self, gui_state: GuiStateStore | None = None) -> None:
         super().__init__()
+        self._gui_state = gui_state if gui_state is not None else GuiStateStore()
         self.setWindowTitle(f"Bilibili 直播掉宝助手 {APP_VERSION}")
         self.resize(1040, 760)
         self.setMinimumSize(860, 620)
@@ -106,6 +110,8 @@ class MinerGUI(QMainWindow):
             post_ui_task=self._post_ui_task,
         )
         self._install_logging()
+        self._restore_window_geometry()
+        self._restore_last_config()
 
         self._log_timer = QTimer(self)
         self._log_timer.setInterval(120)
@@ -167,6 +173,42 @@ class MinerGUI(QMainWindow):
         self._log_toggle_btn = widgets.log_toggle_btn
         self.claim_rewards_btn = widgets.claim_rewards_btn
         self._log_expanded = False
+
+    # ---------- local GUI state ----------
+
+    def _restore_window_geometry(self) -> None:
+        geometry = self._gui_state.window_geometry()
+        if not geometry.isEmpty() and self.restoreGeometry(geometry):
+            return
+        self._center_on_primary_screen()
+
+    def _center_on_primary_screen(self) -> None:
+        screen = QApplication.primaryScreen()
+        if screen is None:
+            return
+        available = screen.availableGeometry()
+        x = available.left() + max(0, (available.width() - self.width()) // 2)
+        y = available.top() + max(0, (available.height() - self.height()) // 2)
+        self.move(x, y)
+
+    def _restore_last_config(self) -> None:
+        path = self._gui_state.last_config_path()
+        if path is None:
+            return
+        if not path.is_file():
+            logging.getLogger(__name__).warning(
+                "上次使用的配置文件不存在，已取消自动加载: %s",
+                path,
+            )
+            self._gui_state.clear_last_config_path()
+            self._gui_state.sync()
+            return
+        self._load_config_path(
+            path,
+            show_error=False,
+            remember=False,
+            automatic=True,
+        )
 
     # ---------- logging / cross-thread ----------
 
@@ -522,6 +564,11 @@ class MinerGUI(QMainWindow):
     # ---------- close ----------
 
     def closeEvent(self, event: QCloseEvent) -> None:
+        try:
+            self._gui_state.set_window_geometry(self.saveGeometry())
+            self._gui_state.sync()
+        except Exception:
+            logging.getLogger(__name__).exception("保存 GUI 状态失败")
         self._ui_alive = False
         try:
             self.stop()
@@ -533,37 +580,72 @@ class MinerGUI(QMainWindow):
 
     # ---------- config load/save ----------
 
+    def _apply_config_values(self, values: GuiConfigValues) -> None:
+        self.cookie_edit.setText(values.cookie)
+        self.rooms_edit.setText(values.rooms_text)
+        self.threads_edit.setText(values.thread_count_text)
+        self.reconnect_edit.setText(values.reconnect_delay_text)
+        self.task_ids_edit.setText(values.task_ids_text)
+        self.task_interval_edit.setText(values.task_query_interval_text)
+        self.notify_urls_edit.setText(values.notify_urls_text)
+        self.disable_task_notify_check.setChecked(not values.notify_on_task_complete)
+        self.verbose_check.setChecked(values.verbose)
+
+    def _load_config_path(
+        self,
+        path: str | Path,
+        *,
+        show_error: bool,
+        remember: bool,
+        automatic: bool,
+    ) -> bool:
+        try:
+            values = values_from_config_data(load_config_data(path))
+            self._apply_config_values(values)
+            if remember:
+                self._gui_state.set_last_config_path(path)
+                self._gui_state.sync()
+            message = "已自动加载上次配置" if automatic else "配置已加载"
+            logging.getLogger(__name__).info("%s: %s", message, path)
+            return True
+        except Exception as exc:
+            if show_error:
+                self._show_error("加载失败", str(exc))
+            else:
+                logging.getLogger(__name__).warning(
+                    "自动加载上次配置失败: %s (%s)",
+                    path,
+                    exc,
+                )
+            return False
+
+    def _config_dialog_path(self, *, save: bool) -> str:
+        path = self._gui_state.last_config_path()
+        if path is not None and path.is_file():
+            return str(path)
+        return "config.json" if save else ""
+
     def load_config(self) -> None:
         path, _ = QFileDialog.getOpenFileName(
             self,
             "加载配置文件",
-            "",
+            self._config_dialog_path(save=False),
             "JSON 文件 (*.json);;所有文件 (*.*)",
         )
         if not path:
             return
-        try:
-            values = values_from_config_data(load_config_data(path))
-            self.cookie_edit.setText(values.cookie)
-            self.rooms_edit.setText(values.rooms_text)
-            self.threads_edit.setText(values.thread_count_text)
-            self.reconnect_edit.setText(values.reconnect_delay_text)
-            self.task_ids_edit.setText(values.task_ids_text)
-            self.task_interval_edit.setText(values.task_query_interval_text)
-            self.notify_urls_edit.setText(values.notify_urls_text)
-            self.disable_task_notify_check.setChecked(
-                not values.notify_on_task_complete
-            )
-            self.verbose_check.setChecked(values.verbose)
-            logging.getLogger(__name__).info("配置已加载: %s", path)
-        except Exception as exc:
-            self._show_error("加载失败", str(exc))
+        self._load_config_path(
+            path,
+            show_error=True,
+            remember=True,
+            automatic=False,
+        )
 
     def save_config(self) -> None:
         path, _ = QFileDialog.getSaveFileName(
             self,
             "保存配置文件",
-            "config.json",
+            self._config_dialog_path(save=True),
             "JSON 文件 (*.json);;所有文件 (*.*)",
         )
         if not path:
@@ -574,6 +656,8 @@ class MinerGUI(QMainWindow):
                 path,
                 build_config_payload(config, verbose=self.verbose_check.isChecked()),
             )
+            self._gui_state.set_last_config_path(path)
+            self._gui_state.sync()
             logging.getLogger(__name__).info("配置已保存: %s", path)
         except Exception as exc:
             self._show_error("保存失败", str(exc))

--- a/tests/test_gui_persistence.py
+++ b/tests/test_gui_persistence.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PySide6.QtCore import QSettings
+from PySide6.QtWidgets import QApplication, QFileDialog
+
+from bilibili_drops_miner.gui_parts.app_style import configure_qt_app
+from bilibili_drops_miner.gui_parts.config_io import save_config_data
+from bilibili_drops_miner.gui_parts.gui_state import GuiStateStore
+from bilibili_drops_miner.gui_parts.main_window import MinerGUI
+
+
+class GuiPersistenceTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.app = QApplication.instance() or QApplication([])
+        configure_qt_app(cls.app)
+
+    @staticmethod
+    def _state_for(directory: str) -> GuiStateStore:
+        settings = QSettings(
+            str(Path(directory) / "gui.ini"),
+            QSettings.IniFormat,
+        )
+        return GuiStateStore(settings)
+
+    @staticmethod
+    def _config_payload() -> dict[str, object]:
+        return {
+            "cookie": "SESSDATA=test; bili_jct=test",
+            "room_ids": [123, 456],
+            "thread_count": 3,
+            "reconnect_delay_seconds": 11,
+            "enable_web_heartbeat": True,
+            "task_ids": ["task-a", "task-b"],
+            "task_query_interval_seconds": 42,
+            "notify_urls": ["gotify://example.invalid/token"],
+            "notify_on_task_complete": False,
+            "verbose": True,
+        }
+
+    def test_first_launch_geometry_intersects_primary_screen(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            window = MinerGUI(gui_state=self._state_for(temp_dir))
+            try:
+                screen = QApplication.primaryScreen()
+                self.assertIsNotNone(screen)
+                self.assertTrue(
+                    window.frameGeometry().intersects(screen.availableGeometry())
+                )
+            finally:
+                window.close()
+
+    def test_window_geometry_is_saved_and_restored(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            state = self._state_for(temp_dir)
+            first = MinerGUI(gui_state=state)
+            first.resize(860, 700)
+            first.move(20, 30)
+            first.show()
+            self.app.processEvents()
+            expected_size = first.size()
+            first.close()
+
+            self.assertFalse(state.window_geometry().isEmpty())
+
+            second = MinerGUI(gui_state=state)
+            try:
+                self.assertEqual(second.size(), expected_size)
+            finally:
+                second.close()
+
+    def test_startup_auto_loads_last_config(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_path = Path(temp_dir) / "config.json"
+            save_config_data(config_path, self._config_payload())
+            state = self._state_for(temp_dir)
+            state.set_last_config_path(config_path)
+            state.sync()
+
+            window = MinerGUI(gui_state=state)
+            try:
+                self.assertEqual(
+                    window.cookie_edit.text(),
+                    "SESSDATA=test; bili_jct=test",
+                )
+                self.assertEqual(window.rooms_edit.text(), "123,456")
+                self.assertEqual(window.threads_edit.text(), "3")
+                self.assertEqual(window.reconnect_edit.text(), "11")
+                self.assertEqual(window.task_ids_edit.text(), "task-a,task-b")
+                self.assertEqual(window.task_interval_edit.text(), "42")
+                self.assertEqual(
+                    window.notify_urls_edit.text(),
+                    "gotify://example.invalid/token",
+                )
+                self.assertTrue(window.disable_task_notify_check.isChecked())
+                self.assertTrue(window.verbose_check.isChecked())
+            finally:
+                window.close()
+
+    def test_missing_last_config_path_is_forgotten(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            state = self._state_for(temp_dir)
+            state.set_last_config_path(Path(temp_dir) / "missing.json")
+            state.sync()
+
+            window = MinerGUI(gui_state=state)
+            try:
+                self.assertIsNone(state.last_config_path())
+                self.assertEqual(window.cookie_edit.text(), "")
+                self.assertEqual(window.rooms_edit.text(), "23612045")
+            finally:
+                window.close()
+
+    def test_invalid_last_config_does_not_open_modal_or_forget_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_path = Path(temp_dir) / "invalid.json"
+            config_path.write_text("not-json", encoding="utf-8")
+            state = self._state_for(temp_dir)
+            state.set_last_config_path(config_path)
+            state.sync()
+
+            window = MinerGUI(gui_state=state)
+            try:
+                self.assertEqual(state.last_config_path(), config_path.resolve())
+                self.assertEqual(window.cookie_edit.text(), "")
+            finally:
+                window.close()
+
+    def test_manual_load_remembers_config_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_path = Path(temp_dir) / "loaded.json"
+            save_config_data(config_path, self._config_payload())
+            state = self._state_for(temp_dir)
+            window = MinerGUI(gui_state=state)
+            try:
+                with patch.object(
+                    QFileDialog,
+                    "getOpenFileName",
+                    return_value=(str(config_path), "JSON 文件 (*.json)"),
+                ):
+                    window.load_config()
+
+                self.assertEqual(state.last_config_path(), config_path.resolve())
+                self.assertEqual(window.rooms_edit.text(), "123,456")
+            finally:
+                window.close()
+
+    def test_manual_save_remembers_config_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_path = Path(temp_dir) / "saved.json"
+            state = self._state_for(temp_dir)
+            window = MinerGUI(gui_state=state)
+            window.cookie_edit.setText("SESSDATA=test; bili_jct=test")
+            try:
+                with patch.object(
+                    QFileDialog,
+                    "getSaveFileName",
+                    return_value=(str(config_path), "JSON 文件 (*.json)"),
+                ):
+                    window.save_config()
+
+                self.assertEqual(state.last_config_path(), config_path.resolve())
+                payload = json.loads(config_path.read_text(encoding="utf-8"))
+                self.assertEqual(payload["cookie"], "SESSDATA=test; bili_jct=test")
+            finally:
+                window.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gui_state.py
+++ b/tests/test_gui_state.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from PySide6.QtCore import QByteArray, QSettings
+
+from bilibili_drops_miner.gui_parts.gui_state import (
+    LAST_CONFIG_PATH_KEY,
+    WINDOW_GEOMETRY_KEY,
+    GuiStateStore,
+)
+
+
+class GuiStateStoreTests(unittest.TestCase):
+    def test_geometry_round_trip(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            settings_path = Path(temp_dir) / "gui.ini"
+            state = GuiStateStore(QSettings(str(settings_path), QSettings.IniFormat))
+            geometry = QByteArray(b"saved-window-geometry")
+
+            state.set_window_geometry(geometry)
+            state.sync()
+
+            restored = GuiStateStore(
+                QSettings(str(settings_path), QSettings.IniFormat)
+            )
+            self.assertEqual(restored.window_geometry(), geometry)
+
+    def test_last_config_path_is_absolute_and_can_be_cleared(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            settings = QSettings(
+                str(Path(temp_dir) / "gui.ini"),
+                QSettings.IniFormat,
+            )
+            state = GuiStateStore(settings)
+            config_path = Path(temp_dir) / "config.json"
+
+            state.set_last_config_path(config_path)
+            state.sync()
+
+            self.assertEqual(state.last_config_path(), config_path.resolve())
+            self.assertEqual(
+                set(settings.allKeys()),
+                {LAST_CONFIG_PATH_KEY},
+            )
+
+            state.clear_last_config_path()
+            state.sync()
+
+            self.assertIsNone(state.last_config_path())
+            self.assertNotIn(LAST_CONFIG_PATH_KEY, settings.allKeys())
+
+    def test_only_expected_gui_state_keys_are_written(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            settings = QSettings(
+                str(Path(temp_dir) / "gui.ini"),
+                QSettings.IniFormat,
+            )
+            state = GuiStateStore(settings)
+
+            state.set_window_geometry(QByteArray(b"geometry"))
+            state.set_last_config_path(Path(temp_dir) / "config.json")
+            state.sync()
+
+            self.assertEqual(
+                set(settings.allKeys()),
+                {WINDOW_GEOMETRY_KEY, LAST_CONFIG_PATH_KEY},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_macos_gui.py
+++ b/tests/test_macos_gui.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 from unittest.mock import patch
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
+from PySide6.QtCore import QSettings
 from PySide6.QtWidgets import QApplication, QPushButton
 
 from bilibili_drops_miner.gui_parts.browser_sniffer import (
@@ -17,6 +19,7 @@ from bilibili_drops_miner.gui_parts.browser_utils import (
     find_browser_binary,
 )
 from bilibili_drops_miner.gui_parts.app_style import configure_qt_app
+from bilibili_drops_miner.gui_parts.gui_state import GuiStateStore
 from bilibili_drops_miner.gui_parts.main_window import APP_VERSION, MinerGUI
 
 
@@ -72,30 +75,39 @@ class GuiParitySmokeTests(unittest.TestCase):
         configure_qt_app(cls.app)
 
     def test_all_desktop_actions_are_present(self) -> None:
-        window = MinerGUI()
-        try:
-            window.show()
-            self.app.processEvents()
-            self.assertEqual(
-                window.windowTitle(), f"Bilibili 直播掉宝助手 {APP_VERSION}"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            state = GuiStateStore(
+                QSettings(
+                    os.path.join(temp_dir, "gui.ini"),
+                    QSettings.IniFormat,
+                )
             )
-            labels = {button.text() for button in window.findChildren(QPushButton)}
-            self.assertTrue(
-                {
-                    "自动获取",
-                    "启动",
-                    "停止",
-                    "加载配置",
-                    "保存配置",
-                    "清空日志",
-                    "领取奖励",
-                    "手动刷新",
-                    "▶ 运行日志",
-                }.issubset(labels)
-            )
-        finally:
-            window.close()
-            self.app.processEvents()
+            window = MinerGUI(gui_state=state)
+            try:
+                window.show()
+                self.app.processEvents()
+                self.assertEqual(
+                    window.windowTitle(), f"Bilibili 直播掉宝助手 {APP_VERSION}"
+                )
+                labels = {
+                    button.text() for button in window.findChildren(QPushButton)
+                }
+                self.assertTrue(
+                    {
+                        "自动获取",
+                        "启动",
+                        "停止",
+                        "加载配置",
+                        "保存配置",
+                        "清空日志",
+                        "领取奖励",
+                        "手动刷新",
+                        "▶ 运行日志",
+                    }.issubset(labels)
+                )
+            finally:
+                window.close()
+                self.app.processEvents()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 变更

- 通过 QSettings 保存和恢复主窗口几何，首次启动居中主屏
- 记录最近成功加载或保存的配置文件路径，启动时自动加载
- 配置路径失效时安全回退，并补充隔离测试
- Actions 仅构建 Windows 和 macOS GUI，不再生成 CLI 可执行文件

## 测试

- python -X faulthandler -m unittest discover -s tests -v（51 项通过）
- GitHub Actions YAML 解析校验通过

Closes #35
Closes #36